### PR TITLE
Fix frontend route pattern and CF Access policy

### DIFF
--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -9,6 +9,6 @@
     "binding": "ASSETS"
   },
   "routes": [
-    { "pattern": "cloudpass.nerotechs.com", "zone_name": "nerotechs.com" }
+    { "pattern": "cloudpass.nerotechs.com/*", "zone_name": "nerotechs.com" }
   ]
 }

--- a/terraform/access.tf
+++ b/terraform/access.tf
@@ -33,15 +33,12 @@ resource "cloudflare_zero_trust_access_application" "cloud_pass" {
   domain           = "${var.app_subdomain}.${var.domain}"
   type             = "self_hosted"
   session_duration = "24h"
-}
 
-# CF Access Policy — allow everyone (or restrict by email domain)
-resource "cloudflare_zero_trust_access_policy" "allow_all" {
-  account_id = var.account_id
-  decision   = "allow"
-  name       = "Allow authenticated users"
-
-  include = [{
-    everyone = {}
+  policies = [{
+    decision = "allow"
+    name     = "Allow authenticated users"
+    include  = [{
+      everyone = {}
+    }]
   }]
 }


### PR DESCRIPTION
## Summary
- Add `/*` wildcard to frontend Workers route pattern (was causing 522 errors)
- Inline CF Access policy on application resource (Cloudflare provider v5 syntax)

## Test plan
- [ ] Verify `https://cloudpass.nerotechs.com` loads after CF Access login
- [ ] Verify API calls succeed with auth cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)