### PR TITLE
fix: enable logout by injecting NEXT_PUBLIC_CF_TEAM_DOMAIN into frontend build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -26,5 +26,6 @@ jobs:
         run: bun run deploy
         env:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_CF_TEAM_DOMAIN: ${{ vars.NEXT_PUBLIC_CF_TEAM_DOMAIN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

Clicking **Logout** does nothing — the user stays signed in.

`AuthContext.logout()` guards the Cloudflare Access logout redirect behind `NEXT_PUBLIC_CF_TEAM_DOMAIN`:

```tsx
const logout = () => {
  setUser(null);
  if (CF_TEAM_DOMAIN) {                       // empty → falsy → skipped
    window.location.href = `https://${CF_TEAM_DOMAIN}.cloudflareaccess.com/cdn-cgi/access/logout`;
  }
};
```

That variable was never provided to the production build. `NEXT_PUBLIC_*` vars are inlined at **build time**, but `deploy-frontend.yml` only passed `NEXT_PUBLIC_API_URL`. So the value was `undefined`, the guard was false, and logout just cleared in-memory React state without actually signing out via CF Access.

## Fix

- Inject `NEXT_PUBLIC_CF_TEAM_DOMAIN` into the OpenNext build step from the GitHub Actions repo variable.
- Repo variable already set: `NEXT_PUBLIC_CF_TEAM_DOMAIN=cloud-pass` (matches `terraform/terraform.tfvars`), producing `https://cloud-pass.cloudflareaccess.com/cdn-cgi/access/logout`.

`frontend/.env.local` is gitignored and set locally to the same value for dev.

## Verification

Takes effect on the next `deploy-frontend` run, which will inline the value into the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)