### PR TITLE
feat: content domains with weighted per-domain question selection

### DIFF
--- a/workers-api/drizzle/0002_mixed_blade.sql
+++ b/workers-api/drizzle/0002_mixed_blade.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `exam_domains` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`exam_id` integer NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`weight` integer NOT NULL,
+	`order_index` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`exam_id`) REFERENCES `exams`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_exam_domains_exam_code` ON `exam_domains` (`exam_id`,`code`);--> statement-breakpoint
+CREATE INDEX `idx_exam_domains_exam_id` ON `exam_domains` (`exam_id`);--> statement-breakpoint
+ALTER TABLE `questions` ADD `domain_id` integer REFERENCES exam_domains(id);--> statement-breakpoint
+CREATE INDEX `idx_questions_domain_id` ON `questions` (`domain_id`);

--- a/workers-api/drizzle/meta/0002_snapshot.json
+++ b/workers-api/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1019 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c5d0633c-48f0-410a-a139-8a1cd5f126b4",
+  "prevId": "039d54e8-5525-48a0-9fdf-84f5ac89e4d7",
+  "tables": {
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "uq_user_bookmark": {
+          "name": "uq_user_bookmark",
+          "columns": [
+            "user_id",
+            "question_id"
+          ],
+          "isUnique": true
+        },
+        "idx_bookmarks_user_id": {
+          "name": "idx_bookmarks_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_question_id_questions_id_fk": {
+          "name": "bookmarks_question_id_questions_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_domains": {
+      "name": "exam_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_exam_domains_exam_code": {
+          "name": "idx_exam_domains_exam_code",
+          "columns": [
+            "exam_id",
+            "code"
+          ],
+          "isUnique": true
+        },
+        "idx_exam_domains_exam_id": {
+          "name": "idx_exam_domains_exam_id",
+          "columns": [
+            "exam_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exam_domains_exam_id_exams_id_fk": {
+          "name": "exam_domains_exam_id_exams_id_fk",
+          "tableFrom": "exam_domains",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_session_questions": {
+      "name": "exam_session_questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_option_ids": {
+          "name": "selected_option_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_esq_session_id": {
+          "name": "idx_esq_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exam_session_questions_session_id_exam_sessions_id_fk": {
+          "name": "exam_session_questions_session_id_exam_sessions_id_fk",
+          "tableFrom": "exam_session_questions",
+          "tableTo": "exam_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_session_questions_question_id_questions_id_fk": {
+          "name": "exam_session_questions_question_id_questions_id_fk",
+          "tableFrom": "exam_session_questions",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_sessions": {
+      "name": "exam_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "num_questions": {
+          "name": "num_questions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pass_percentage": {
+          "name": "pass_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_answered": {
+          "name": "total_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elapsed_seconds": {
+          "name": "elapsed_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_exam_sessions_user_id": {
+          "name": "idx_exam_sessions_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_exam_sessions_exam_id": {
+          "name": "idx_exam_sessions_exam_id",
+          "columns": [
+            "exam_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exam_sessions_user_id_users_id_fk": {
+          "name": "exam_sessions_user_id_users_id_fk",
+          "tableFrom": "exam_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exam_sessions_exam_id_exams_id_fk": {
+          "name": "exam_sessions_exam_id_exams_id_fk",
+          "tableFrom": "exam_sessions",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exams": {
+      "name": "exams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_questions": {
+          "name": "total_questions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "num_questions": {
+          "name": "num_questions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 65
+        },
+        "pass_percentage": {
+          "name": "pass_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 75
+        },
+        "time_limit_minutes": {
+          "name": "time_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 180
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_exams_code": {
+          "name": "idx_exams_code",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "idx_exams_provider_id": {
+          "name": "idx_exams_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exams_provider_id_providers_id_fk": {
+          "name": "exams_provider_id_providers_id_fk",
+          "tableFrom": "exams",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "options": {
+      "name": "options",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_options_question_id": {
+          "name": "idx_options_question_id",
+          "columns": [
+            "question_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "options_question_id_questions_id_fk": {
+          "name": "options_question_id_questions_id_fk",
+          "tableFrom": "options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_providers_name": {
+          "name": "idx_providers_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_correct": {
+          "name": "num_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_questions_exam_id": {
+          "name": "idx_questions_exam_id",
+          "columns": [
+            "exam_id"
+          ],
+          "isUnique": false
+        },
+        "idx_questions_external_id": {
+          "name": "idx_questions_external_id",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "idx_questions_domain_id": {
+          "name": "idx_questions_domain_id",
+          "columns": [
+            "domain_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "questions_exam_id_exams_id_fk": {
+          "name": "questions_exam_id_exams_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "exams",
+          "columnsFrom": [
+            "exam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "questions_domain_id_exam_domains_id_fk": {
+          "name": "questions_domain_id_exam_domains_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "exam_domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_progress": {
+      "name": "user_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_option_ids": {
+          "name": "selected_option_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "uq_user_question": {
+          "name": "uq_user_question",
+          "columns": [
+            "user_id",
+            "question_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_progress_user_id": {
+          "name": "idx_user_progress_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_progress_user_id_users_id_fk": {
+          "name": "user_progress_user_id_users_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_progress_question_id_questions_id_fk": {
+          "name": "user_progress_question_id_questions_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/workers-api/drizzle/meta/_journal.json
+++ b/workers-api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773016248227,
       "tag": "0001_free_colonel_america",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1782653451800,
+      "tag": "0002_mixed_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/workers-api/src/db/schema/exam-domains.ts
+++ b/workers-api/src/db/schema/exam-domains.ts
@@ -1,0 +1,20 @@
+import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { exams } from "./exams";
+
+export const examDomains = sqliteTable(
+  "exam_domains",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    examId: integer("exam_id")
+      .notNull()
+      .references(() => exams.id, { onDelete: "cascade" }),
+    code: text("code").notNull(), // stable per-exam key, e.g. "agent-arch"
+    name: text("name").notNull(), // display name
+    weight: integer("weight").notNull(), // relative weight, normalized at selection time
+    orderIndex: integer("order_index").notNull().default(0),
+  },
+  (table) => [
+    uniqueIndex("idx_exam_domains_exam_code").on(table.examId, table.code),
+    index("idx_exam_domains_exam_id").on(table.examId),
+  ]
+);

--- a/workers-api/src/db/schema/index.ts
+++ b/workers-api/src/db/schema/index.ts
@@ -1,6 +1,7 @@
 export { users } from "./users";
 export { providers } from "./providers";
 export { exams } from "./exams";
+export { examDomains } from "./exam-domains";
 export { questions } from "./questions";
 export { options } from "./options";
 export { userProgress } from "./user-progress";

--- a/workers-api/src/db/schema/questions.ts
+++ b/workers-api/src/db/schema/questions.ts
@@ -1,6 +1,7 @@
 import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 import { exams } from "./exams";
+import { examDomains } from "./exam-domains";
 
 export const questions = sqliteTable(
   "questions",
@@ -9,6 +10,9 @@ export const questions = sqliteTable(
     examId: integer("exam_id")
       .notNull()
       .references(() => exams.id, { onDelete: "cascade" }),
+    domainId: integer("domain_id").references(() => examDomains.id, {
+      onDelete: "set null",
+    }), // nullable — null for exams without domains (backward compat)
     externalId: text("external_id").notNull(),
     questionText: text("question_text").notNull(),
     questionType: text("question_type").notNull(), // "single" | "multi"
@@ -26,5 +30,6 @@ export const questions = sqliteTable(
   (table) => [
     index("idx_questions_exam_id").on(table.examId),
     index("idx_questions_external_id").on(table.externalId),
+    index("idx_questions_domain_id").on(table.domainId),
   ]
 );

--- a/workers-api/src/routes/exams.ts
+++ b/workers-api/src/routes/exams.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
-import { eq, and } from "drizzle-orm";
+import { eq, and, count } from "drizzle-orm";
 import type { AppEnv } from "../types/env";
-import { exams, providers, examSessions } from "../db/schema";
+import { exams, examDomains, questions, providers, examSessions } from "../db/schema";
 import { getProgressSummary } from "../services/progress-service";
 import { AppError } from "../lib/errors";
 
@@ -80,6 +80,21 @@ examRoutes.get("/:id", async (c) => {
 
   const progressSummary = await getProgressSummary(db, examId, user.id);
 
+  // Content domains (with per-domain question counts). Empty for exams without domains.
+  const domainRows = await db
+    .select({
+      id: examDomains.id,
+      code: examDomains.code,
+      name: examDomains.name,
+      weight: examDomains.weight,
+      questionCount: count(questions.id),
+    })
+    .from(examDomains)
+    .leftJoin(questions, eq(questions.domainId, examDomains.id))
+    .where(eq(examDomains.examId, examId))
+    .groupBy(examDomains.id)
+    .orderBy(examDomains.orderIndex);
+
   // Find active session
   const activeSession = await db.query.examSessions.findFirst({
     where: and(
@@ -103,6 +118,13 @@ examRoutes.get("/:id", async (c) => {
     provider_name: exam.providerName,
     progress_summary: progressSummary,
     active_session_id: activeSession?.id ?? null,
+    domains: domainRows.map((d) => ({
+      id: d.id,
+      code: d.code,
+      name: d.name,
+      weight: d.weight,
+      question_count: d.questionCount,
+    })),
   });
 });
 

--- a/workers-api/src/services/exam-session-service.ts
+++ b/workers-api/src/services/exam-session-service.ts
@@ -2,6 +2,7 @@ import { eq, and, sql, count, inArray, desc, asc } from "drizzle-orm";
 import type { Database } from "../db/client";
 import {
   exams,
+  examDomains,
   questions,
   options,
   examSessions,
@@ -50,16 +51,121 @@ function calculateForgettingFactor(
   return 1 - retention;
 }
 
+// Weighted random sampling without replacement.
+function weightedSampleWithoutReplacement(
+  items: { id: number; weight: number }[],
+  n: number
+): number[] {
+  const selected: number[] = [];
+  const remaining = [...items];
+  const target = Math.min(n, remaining.length);
+
+  for (let i = 0; i < target; i++) {
+    const totalWeight = remaining.reduce((sum, item) => sum + item.weight, 0);
+    let random = Math.random() * totalWeight;
+
+    // Default to the last item to stay robust against floating-point drift
+    // (e.g. if accumulated subtraction never quite crosses zero).
+    let picked = remaining.length - 1;
+    for (let j = 0; j < remaining.length; j++) {
+      random -= remaining[j].weight;
+      if (random <= 0) {
+        picked = j;
+        break;
+      }
+    }
+    selected.push(remaining[picked].id);
+    remaining.splice(picked, 1);
+  }
+
+  return selected;
+}
+
+// Allocate `total` slots across keyed buckets proportionally to weight, capped at
+// each bucket's capacity, redistributing any overflow to buckets that still have
+// room. Always allocates exactly min(total, sum(caps)) and always terminates.
+function allocateByWeightWithCaps(
+  entries: { key: number; weight: number; cap: number }[],
+  total: number
+): Map<number, number> {
+  const alloc = new Map<number, number>(entries.map((e) => [e.key, 0]));
+  const totalCap = entries.reduce((s, e) => s + e.cap, 0);
+  let remaining = Math.min(total, totalCap);
+  let active = entries.filter((e) => e.cap > 0);
+
+  while (remaining > 0 && active.length > 0) {
+    const wsum = active.reduce((s, e) => s + Math.max(e.weight, 0), 0);
+
+    if (wsum <= 0) {
+      // No usable weights — fall back to round-robin so progress is guaranteed.
+      for (const e of active) {
+        if (remaining <= 0) break;
+        if ((alloc.get(e.key) ?? 0) < e.cap) {
+          alloc.set(e.key, (alloc.get(e.key) ?? 0) + 1);
+          remaining--;
+        }
+      }
+      active = active.filter((e) => (alloc.get(e.key) ?? 0) < e.cap);
+      continue;
+    }
+
+    // Proportional pass (floor), capped at remaining room per bucket.
+    let passAllocated = 0;
+    const remainders: { key: number; cap: number; frac: number }[] = [];
+    for (const e of active) {
+      const ideal = (remaining * Math.max(e.weight, 0)) / wsum;
+      const room = e.cap - (alloc.get(e.key) ?? 0);
+      const give = Math.min(Math.floor(ideal), room);
+      if (give > 0) {
+        alloc.set(e.key, (alloc.get(e.key) ?? 0) + give);
+        passAllocated += give;
+      }
+      if (give < room) {
+        remainders.push({ key: e.key, cap: e.cap, frac: ideal - Math.floor(ideal) });
+      }
+    }
+    remaining -= passAllocated;
+
+    // Hand out the leftover by largest fractional remainder, +1 each, respecting caps.
+    remainders.sort((a, b) => b.frac - a.frac);
+    for (const r of remainders) {
+      if (remaining <= 0) break;
+      if ((alloc.get(r.key) ?? 0) < r.cap) {
+        alloc.set(r.key, (alloc.get(r.key) ?? 0) + 1);
+        remaining--;
+      }
+    }
+
+    // Guarantee forward progress if a pass allocated nothing (all ideals < 1).
+    if (passAllocated === 0 && remaining > 0) {
+      for (const e of active) {
+        if (remaining <= 0) break;
+        if ((alloc.get(e.key) ?? 0) < e.cap) {
+          alloc.set(e.key, (alloc.get(e.key) ?? 0) + 1);
+          remaining--;
+        }
+      }
+    }
+
+    active = active.filter((e) => (alloc.get(e.key) ?? 0) < e.cap);
+  }
+
+  return alloc;
+}
+
 async function selectWeightedQuestions(
   db: Database,
   examId: number,
   userId: number,
   numToSelect: number
 ): Promise<number[]> {
-  // 4 parallel queries
-  const [allQuestions, historyRows, practiceRows, bookmarkRows] = await Promise.all([
-    // 1. All question IDs for exam
-    db.select({ id: questions.id }).from(questions).where(eq(questions.examId, examId)),
+  // 5 parallel queries
+  const [allQuestions, historyRows, practiceRows, bookmarkRows, domainRows] = await Promise.all([
+    // 1. All question IDs (+ domain) for exam
+    db
+      .select({ id: questions.id, domainId: questions.domainId })
+      .from(questions)
+      .where(eq(questions.examId, examId)),
 
     // 2. Exam session history with correctCount, lastAnsweredAt, lastWasCorrect
     db
@@ -118,6 +224,13 @@ async function selectWeightedQuestions(
       .where(
         and(eq(bookmarks.userId, userId), eq(questions.examId, examId))
       ),
+
+    // 5. Content domains for this exam (weights drive per-domain quotas)
+    db
+      .select({ id: examDomains.id, weight: examDomains.weight })
+      .from(examDomains)
+      .where(eq(examDomains.examId, examId))
+      .orderBy(examDomains.orderIndex),
   ]);
 
   const allIds = allQuestions.map((q) => q.id);
@@ -239,25 +352,54 @@ async function selectWeightedQuestions(
     return { id, weight };
   });
 
-  // Weighted random sampling without replacement
-  const selected: number[] = [];
-  const remaining = [...weighted];
+  // No domains configured → global weighted selection (backward compatible).
+  if (domainRows.length === 0) {
+    return weightedSampleWithoutReplacement(weighted, numToSelect);
+  }
 
-  for (let i = 0; i < numToSelect; i++) {
-    const totalWeight = remaining.reduce((sum, item) => sum + item.weight, 0);
-    let random = Math.random() * totalWeight;
+  // Domain-aware selection: domain weights set per-domain quotas; the scoring
+  // above decides which specific questions fill each quota.
+  const weightById = new Map(weighted.map((w) => [w.id, w.weight]));
+  const itemsByDomain = new Map<number, { id: number; weight: number }[]>();
+  const unassigned: { id: number; weight: number }[] = [];
 
-    for (let j = 0; j < remaining.length; j++) {
-      random -= remaining[j].weight;
-      if (random <= 0) {
-        selected.push(remaining[j].id);
-        remaining.splice(j, 1);
-        break;
-      }
+  for (const q of allQuestions) {
+    const item = { id: q.id, weight: weightById.get(q.id) ?? WEIGHT_CONFIG.BASE };
+    if (q.domainId != null) {
+      const bucket = itemsByDomain.get(q.domainId);
+      if (bucket) bucket.push(item);
+      else itemsByDomain.set(q.domainId, [item]);
+    } else {
+      unassigned.push(item);
     }
   }
 
-  return selected;
+  // Allocate quotas across domains proportionally to weight, capped at how many
+  // questions each domain actually has (under-filled domains redistribute).
+  const quotaByDomain = allocateByWeightWithCaps(
+    domainRows.map((d) => ({
+      key: d.id,
+      weight: d.weight,
+      cap: itemsByDomain.get(d.id)?.length ?? 0,
+    })),
+    numToSelect
+  );
+
+  const selected: number[] = [];
+  for (const [domainId, items] of itemsByDomain) {
+    const quota = quotaByDomain.get(domainId) ?? 0;
+    if (quota > 0) selected.push(...weightedSampleWithoutReplacement(items, quota));
+  }
+
+  // Fill any shortfall (rounding, under-capacity domains, or questions with no
+  // domain) from the unassigned pool so the session always reaches numToSelect.
+  const shortfall = numToSelect - selected.length;
+  if (shortfall > 0 && unassigned.length > 0) {
+    selected.push(...weightedSampleWithoutReplacement(unassigned, shortfall));
+  }
+
+  // Mix domains together so questions aren't clustered by domain.
+  return shuffleArray(selected);
 }
 
 function shuffleArray<T>(arr: T[]): T[] {


### PR DESCRIPTION
## What & why

Each certification exam is organized into **content domains**, each with a **weight**. Session generation should pick questions from each domain in proportion to its weight (e.g. CCA-F's five domains). This adds that, while keeping exams without domains (e.g. MLS) working exactly as before.

## Changes (API + DB)

- **Schema**: new `exam_domains` table (`exam_id`, `code`, `name`, `weight`, `order_index`) + nullable `questions.domain_id`. Migration `drizzle/0002_mixed_blade.sql` is non-destructive (`CREATE TABLE` + `ADD COLUMN`).
- **Selection** (`exam-session-service.ts`): domain weights set per-domain **quotas** (largest-remainder); the existing 6-dimension scoring picks which questions fill each quota. Quotas are **capped at each domain's available count**, and any shortfall (rounding, under-capacity domains, or unassigned questions) is **redistributed** so a session always reaches `num_questions`. Scoring logic unchanged — extracted into reusable helpers.
- **Import** (`schemas/import.ts`, `import-service.ts`): the import payload now supports an optional `exam.domains` array and an optional per-question `domain` code. Domains are upserted by (exam, code); each question's domain code resolves to `domain_id` on insert and is **backfilled on re-import**; an undeclared domain code is rejected with 422.
- **API**: `GET /exams/:id` additively returns a `domains` array with per-domain `question_count`.

## Backward compatibility

- `questions.domain_id` is nullable; `domains`/`domain` are optional. Exams/payloads with no domains run the original global weighted selection unchanged.

## Verification (local D1 + live `wrangler dev`)

- **Selection** — weights 50/25/15/5/5, `num_questions=20`, capacities A30/B30/**C2**/**D0**/E30 → **A:11 B:6 C:2 D:0 E:1 = 20** on every trial (C capped at 2, D's slot redistributed). Total always equals `num_questions`. No-domain exam returns `num_questions` via the unchanged path. Small pool (`num_questions` > pool) returns all available, no error.
- **Import** — domain-aware payload creates 5 domains, assigns questions to the right domains; unknown domain code → 422; re-import backfills an existing question's domain.
- `tsc --noEmit` clean.

## Deploy note

Merging applies the remote D1 migration automatically (`deploy-workers-api.yml` runs `wrangler d1 migrations apply --remote` before deploy). Frontend display intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)